### PR TITLE
#SPOI-5380 Resolve NPE after operator restart.

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/dimensions/DimensionsComputationFlexibleSingleSchemaPOJO.java
+++ b/library/src/main/java/com/datatorrent/lib/dimensions/DimensionsComputationFlexibleSingleSchemaPOJO.java
@@ -40,7 +40,7 @@ public class DimensionsComputationFlexibleSingleSchemaPOJO extends AbstractDimen
   /**
    * Flag indicating whether or not getters need to be created.
    */
-  private boolean needToCreateGetters = true;
+  private transient boolean needToCreateGetters = true;
   /**
    * This is a map from a key name (as defined in the {@link DimensionalConfigurationSchema}) to the getter
    * expression to use for that key.


### PR DESCRIPTION
needToCreateGetters variable is not transient. Because of this when the DimensionComputation POJO operator crashes, it restores from previous state of needToCreateGetters which will be false. Hence the getter objects don't get created when the operator crashes and starts again from previously checkpointed state.
