### PR TITLE
Fix NPE in recovery

### DIFF
--- a/contrib/src/main/java/com/datatorrent/contrib/hdht/HDHTReader.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/hdht/HDHTReader.java
@@ -346,6 +346,7 @@ public class HDHTReader implements Operator, HDHT.Reader
     protected BucketMeta(Comparator<Slice> cmp)
     {
       files = new TreeMap<Slice, BucketFileMeta>(cmp);
+      recoveryStartWalPosition = new HDHTWalManager.WalPosition(0,0);
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
It was fixed in malhar through da2217bb6873756c0340bcdef790ba, somehow missed during migration to  Megh.
