### PR TITLE
SPOI-5557: DimensionsQueryExecutor.executeQuery - should not emit when no data is found

### DIFF
--- a/contrib/src/main/java/com/datatorrent/contrib/dimensions/AbstractAppDataDimensionStoreHDHT.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/dimensions/AbstractAppDataDimensionStoreHDHT.java
@@ -84,11 +84,33 @@ public abstract class AbstractAppDataDimensionStoreHDHT extends DimensionsStoreH
    * This is the factory used to serialize results.
    */
   protected transient MessageSerializerFactory resultSerializerFactory;
+
+  /**
+   * Optional unifier for query result port.
+   */
+  private Unifier<String> queryResultUnifier;
+
+  public void setQueryResultUnifier(Unifier<String> queryResultUnifier)
+  {
+    this.queryResultUnifier = queryResultUnifier;
+  }
+
   /**
    * This is the output port that serialized query results are emitted from.
    */
   @AppData.ResultPort
-  public final transient DefaultOutputPort<String> queryResult = new DefaultOutputPort<String>();
+  public final transient DefaultOutputPort<String> queryResult = new DefaultOutputPort<String>() {
+    @Override
+    public Unifier<String> getUnifier()
+    {
+      if (AbstractAppDataDimensionStoreHDHT.this.queryResultUnifier == null) {
+        return super.getUnifier();
+      } else {
+        return queryResultUnifier;
+      }
+    }
+  };
+
   /**
    * This is the input port from which queries are received.
    */

--- a/contrib/src/main/java/com/datatorrent/contrib/dimensions/DimensionStoreHDHTNonEmptyQueryResultUnifier.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/dimensions/DimensionStoreHDHTNonEmptyQueryResultUnifier.java
@@ -1,0 +1,48 @@
+package com.datatorrent.contrib.dimensions;
+
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.api.Operator.Unifier;
+import com.datatorrent.common.util.BaseOperator;
+import com.datatorrent.lib.appdata.schemas.DataResultDimensional;
+import com.datatorrent.lib.appdata.schemas.Result;
+
+/**
+ * This is a QueryResult unifier for AbstractAppDataDimensionStoreHDHT for port queryResult.
+ * 
+ * The unifier filters out all the data which are having empty query result data.
+ * 
+ * This is specially useful when Store is partitioned and Queries goes to all the stores but
+ * only one store is going to hold the data for the actual results.
+ */
+public class DimensionStoreHDHTNonEmptyQueryResultUnifier extends BaseOperator implements Unifier<String>
+{
+
+  /**
+   * Output port that emits only non-empty dataResults.
+   */
+  public final transient DefaultOutputPort<String> output = new DefaultOutputPort<String>();
+
+  @Override
+  public void process(String tuple)
+  {
+    JSONObject jo = null;
+
+    try {
+      jo = new JSONObject(tuple);
+      if (jo.getString(Result.FIELD_TYPE).equals(DataResultDimensional.TYPE)) {
+        JSONArray dataArray = jo.getJSONArray(Result.FIELD_DATA);
+        if ((dataArray != null) && (dataArray.length() != 0)) {
+          output.emit(tuple);
+        }
+      } else {
+        output.emit(tuple);
+      }
+    } catch (JSONException ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+}


### PR DESCRIPTION
Added optional queryResultUnifier to be returned from queryResult port.
If the unifier is set, then only this will take effect. Otherwise default unifier,
will be used.
Also added a unifier which filters empty data results.
