### PR TITLE
SPOI-6049

### DIFF
--- a/contrib/src/main/java/com/datatorrent/contrib/dimensions/DimensionsStoreHDHT.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/dimensions/DimensionsStoreHDHT.java
@@ -415,6 +415,12 @@ public abstract class DimensionsStoreHDHT extends AbstractSinglePortHDHTWriter<A
     int ddID = gae.getDimensionDescriptorID();
     int aggregatorID = gae.getAggregatorID();
 
+    FieldsDescriptor keyFieldsDescriptor = getKeyDescriptor(schemaID, ddID);
+    FieldsDescriptor valueFieldsDescriptor = getValueDescriptor(schemaID, ddID, aggregatorID);
+
+    gae.getKeys().setFieldDescriptor(keyFieldsDescriptor);
+    gae.getAggregates().setFieldDescriptor(valueFieldsDescriptor);
+
     //Skip data for buckets with greater committed window Ids
     if(!futureBuckets.isEmpty()) {
       long bucket = getBucketForSchema(schemaID);
@@ -426,12 +432,6 @@ public abstract class DimensionsStoreHDHT extends AbstractSinglePortHDHTWriter<A
         return;
       }
     }
-
-    FieldsDescriptor keyFieldsDescriptor = getKeyDescriptor(schemaID, ddID);
-    FieldsDescriptor valueFieldsDescriptor = getValueDescriptor(schemaID, ddID, aggregatorID);
-
-    gae.getKeys().setFieldDescriptor(keyFieldsDescriptor);
-    gae.getAggregates().setFieldDescriptor(valueFieldsDescriptor);
 
     GPOMutable metaData = gae.getMetaData();
 


### PR DESCRIPTION
Always setting metadata on tuples, even when the operator is restored to a window before the committed window.
