### PR TITLE
MLHR-1685: Update cached query result for processed queries

### DIFF
--- a/contrib/src/main/java/com/datatorrent/contrib/hdht/HDHTWriter.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/hdht/HDHTWriter.java
@@ -287,6 +287,16 @@ public class HDHTWriter extends HDHTReader implements CheckpointListener, Operat
     Bucket bucket = getBucket(bucketKey);
     bucket.wal.append(key, value);
     bucket.writeCache.put(key, value);
+    updateQueryResultCache(bucketKey, key, value);
+  }
+
+  private void updateQueryResultCache(long bucketKey, Slice key, byte[] value)
+  {
+    HDSQuery q = queries.get(key);
+    if (q != null) {
+      q.processed = true;
+      q.result = value;
+    }
   }
 
   public void delete(long bucketKey, Slice key) throws IOException


### PR DESCRIPTION
Once query is processed and its result is cached in query, we do not change/discard cached result after new data is a added for the same key. We keep on emitting the old cached value till the query expires. This fix finds the active query and update its cached result if data is changed.
