### PR TITLE
SPOI-6754 Removed hadoop dep in starter app

### DIFF
--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -61,6 +61,7 @@
               <configuration>
                 <outputDirectory>target/deps</outputDirectory>
                 <includeScope>runtime</includeScope>
+		<excludeArtifactIds>hadoop-common, hadoop-auth, hadoop-annotations</excludeArtifactIds>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
Removed Hadoop dependency in starter-app package. Fixed assembly descriptor.
Tested the package with fix, was able to run the app built with dtAssemble
