### PR TITLE
SPOI-7044: Create Expression Evaluator support Java Expression Language

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/expressions/ConversionUtils.java
+++ b/library/src/main/java/com/datatorrent/lib/expressions/ConversionUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 DataTorrent, Inc.
+ * Copyright (c) 2016 DataTorrent, Inc.
  * All rights reserved.
  */
 package com.datatorrent.lib.expressions;

--- a/library/src/main/java/com/datatorrent/lib/expressions/ConversionUtils.java
+++ b/library/src/main/java/com/datatorrent/lib/expressions/ConversionUtils.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2015 DataTorrent, Inc.
+ * All rights reserved.
+ */
+package com.datatorrent.lib.expressions;
+
+import org.apache.commons.lang3.math.NumberUtils;
+
+public class ConversionUtils
+{
+  public static int toInt(double a)
+  {
+    return new Double(a).intValue();
+  }
+
+  public static int toInt(float a)
+  {
+    return new Float(a).intValue();
+  }
+
+  public static int toInt(long a)
+  {
+    return new Long(a).intValue();
+  }
+
+  public static int toInt(byte a)
+  {
+    return new Byte(a).intValue();
+  }
+
+  public static int toInt(short a)
+  {
+    return new Short(a).intValue();
+  }
+
+  public static int toInt(String a)
+  {
+    return NumberUtils.toInt(a);
+  }
+
+  public static long toLong(float a)
+  {
+    return new Float(a).longValue();
+  }
+
+  public static long toLong(double a)
+  {
+    return new Double(a).longValue();
+  }
+
+  public static long toLong(int a)
+  {
+    return new Integer(a).longValue();
+  }
+
+  public static long toLong(byte a)
+  {
+    return new Byte(a).longValue();
+  }
+
+  public static long toLong(short a)
+  {
+    return new Short(a).longValue();
+  }
+
+  public static long toLong(String a)
+  {
+    return NumberUtils.toLong(a);
+  }
+
+  public static int toShort(double a)
+  {
+    return new Double(a).shortValue();
+  }
+
+  public static short toShort(float a)
+  {
+    return new Float(a).shortValue();
+  }
+
+  public static short toShort(long a)
+  {
+    return new Long(a).shortValue();
+  }
+
+  public static short toShort(byte a)
+  {
+    return new Byte(a).shortValue();
+  }
+
+  public static short toShort(int a)
+  {
+    return new Integer(a).shortValue();
+  }
+
+  public static short toShort(String a)
+  {
+    return NumberUtils.toShort(a);
+  }
+
+  public static byte toByte(float a)
+  {
+    return new Float(a).byteValue();
+  }
+
+  public static byte toByte(double a)
+  {
+    return new Double(a).byteValue();
+  }
+
+  public static byte toByte(int a)
+  {
+    return new Integer(a).byteValue();
+  }
+
+  public static byte toByte(long a)
+  {
+    return new Long(a).byteValue();
+  }
+
+  public static byte toByte(short a)
+  {
+    return new Short(a).byteValue();
+  }
+
+  public static byte toByte(String a)
+  {
+    return NumberUtils.toByte(a);
+  }
+
+  public static float toFloat(double a)
+  {
+    return new Double(a).floatValue();
+  }
+
+  public static float toFloat(short a)
+  {
+    return new Short(a).floatValue();
+  }
+
+  public static float toFloat(long a)
+  {
+    return new Long(a).floatValue();
+  }
+
+  public static float toFloat(byte a)
+  {
+    return new Byte(a).floatValue();
+  }
+
+  public static float toFloat(int a)
+  {
+    return new Integer(a).floatValue();
+  }
+
+  public static float toFloat(String a)
+  {
+    return NumberUtils.toFloat(a);
+  }
+
+  public static double toDouble(float a)
+  {
+    return new Float(a).doubleValue();
+  }
+
+  public static double toDouble(byte a)
+  {
+    return new Byte(a).doubleValue();
+  }
+
+  public static double toDouble(int a)
+  {
+    return new Integer(a).doubleValue();
+  }
+
+  public static double toDouble(long a)
+  {
+    return new Long(a).doubleValue();
+  }
+
+  public static double toDouble(short a)
+  {
+    return new Short(a).doubleValue();
+  }
+
+  public static double toDouble(String a)
+  {
+    return NumberUtils.toDouble(a);
+  }
+}

--- a/library/src/main/java/com/datatorrent/lib/expressions/DateTimeUtils.java
+++ b/library/src/main/java/com/datatorrent/lib/expressions/DateTimeUtils.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2015 DataTorrent, Inc.
+ * All rights reserved.
+ */
+package com.datatorrent.lib.expressions;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+public class DateTimeUtils
+{
+  public Date nowDate()
+  {
+    return new Date();
+  }
+
+  public long nowTime()
+  {
+    return System.currentTimeMillis();
+  }
+
+  public Calendar nowCalender()
+  {
+    return Calendar.getInstance();
+  }
+
+  public Calendar nowCalender(String timeZone)
+  {
+    return Calendar.getInstance(TimeZone.getTimeZone(timeZone));
+  }
+}

--- a/library/src/main/java/com/datatorrent/lib/expressions/DateTimeUtils.java
+++ b/library/src/main/java/com/datatorrent/lib/expressions/DateTimeUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 DataTorrent, Inc.
+ * Copyright (c) 2016 DataTorrent, Inc.
  * All rights reserved.
  */
 package com.datatorrent.lib.expressions;

--- a/library/src/main/java/com/datatorrent/lib/expressions/ExpressionEvaluator.java
+++ b/library/src/main/java/com/datatorrent/lib/expressions/ExpressionEvaluator.java
@@ -1,0 +1,422 @@
+/**
+ * Copyright (c) 2015 DataTorrent, Inc.
+ * All rights reserved.
+ */
+package com.datatorrent.lib.expressions;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.codehaus.commons.compiler.CompilerFactoryFactory;
+import org.codehaus.commons.compiler.IScriptEvaluator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is used for evaluating expressions which takes multiple parameter object and the result is returned for that expression.
+ *
+ * The way to reference a variable in an object is ${placeholder.varname}.
+ * The variable will be resolved to its accessible variable or getter method in order. After this the variable can be used as if its a Java variable.
+ *
+ * ExpressionEvaluator also allows you to set extra imports that needs to be added over default is java.lang.*
+ *
+ * ExpressionEvaluator needs to be configured with following configurations as minimal configuration:
+ * 1. Mapping of input object place holders to it corresponding types.
+ * This can be done with setInputObjectPlaceholders method.
+ * 2. Return type of of expression evaluation.
+ * 3. Expression to be evaluated. This is a standard java expression except for referencing the variable inside object JEL syntax needs to be used i.e. ${objectPlaceHolder.varName}
+ *
+ * Expression cab be defined as per JSL 7 syntax:
+ * http://docs.oracle.com/javase/specs/jls/se7/html/jls-14.html
+ */
+public class ExpressionEvaluator
+{
+  private static final Logger logger = LoggerFactory.getLogger(ExpressionEvaluator.class);
+
+  private static final String INP_OBJECT_FUNC_VAR = "obj";
+
+  private static final String GET = "get";
+  private static final String IS = "is";
+
+  private final Map<String, Class> placeholderClassMapping = new HashMap<String, Class>();
+  private final Map<String, Integer> placeholderIndexMapping = new HashMap<String, Integer>();
+  private final Set<String> imports = new HashSet<>();
+
+  /**
+   * Constructor for ExpressionEvaluator.
+   * This constructor will add some default java imports for expressions to be compiled.
+   */
+  public ExpressionEvaluator()
+  {
+    addDefaultImports();
+  }
+
+  /**
+   * This is the Expression interface, object of which will be returned to the evaluated expression.
+   * The person who want to execute the expression is expected to run the execute method with parameters in the same order
+   * as set in setInputObjectPlaceholders method.
+   *
+   * @param <O> This is generic class return type of execute method of expression.
+   */
+  public interface Expression<O>
+  {
+    O execute(Object... obj);
+  }
+
+  /**
+   * This method of ExpressionEvaluator will create a compiled & executable expression which is go as-is as method's content.
+   * The expression provided here is expected to contain a return statement.
+   * If expression does not contain return statement, the method will throw RuntimeException.
+   *
+   * <p>
+   *  Example is as follows:
+   *  Let the expression be <func_expression>
+   *  After compiling and resolving the placeholder, it becomes <compiled_func_expression>
+   *
+   *  The execute method of Expression interface would look like this:
+   *  <return_type> execute(Object... obj)
+   *  {
+   *    <compiled_func_expression>
+   *  }
+   * </p>
+   *
+   * @param expression  String expression which has return statement in it.
+   * @param returnType  Type of class which will be returned by execute method of Expression interface.
+   * @param <O>         Parameterized return class type of expression after evaluation.
+   * @return            Object of type Expression interface having compiled and executable expression.
+   */
+  public <O> Expression<O> createExecutableFunction(String expression, Class<?> returnType)
+  {
+    return createExecutableExpression(expression, returnType, true);
+  }
+
+
+  /**
+   * This method of ExpressionEvaluator will create a compiled & executable expression to which return statement is added.
+   * The expression provided here is not expected to contain a return statement.
+   * Expression should be a single line expression as per JLS 7 as given in:
+   * <a>https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html</a>
+   *
+   * <p>
+   *  Example is as follows:
+   *  Let the expression be <expression>
+   *  After compiling and resolving the placeholder, it becomes <compiled_expression>
+   *
+   *  The execute method of Expression interface would look like this:
+   *  <return_type> execute(Object... obj)
+   *  {
+   *    return ((<return_type>)(<compiled_expression>))
+   *  }
+   * </p>
+   *
+   * @param expression  String expression which has return statement in it.
+   * @param returnType  Type of class which will be returned by execute method of Expression interface.
+   * @param <O>         Parameterized return class type of expression after evaluation.
+   * @return            Object of type Expression interface having compiled and executable expression.
+   */
+  public <O> Expression<O> createExecutableExpression(String expression, Class<?> returnType)
+  {
+    return createExecutableExpression(expression, returnType, false);
+  }
+
+  /**
+   * This is a private which will be called by public method createExecutableExpression & createExecutableFunction.
+   * This method is the main method which converts the given expression into java expression format and compiles it
+   * using Janino.
+   *
+   * The method works in following steps:
+   * <ol>
+   *   <li>Resolve object/variable placeholder to respective types and replace them in expression</li>
+   *   <li>Generate final code to go into execute method of Expression class. Here the final code is generated based
+   *       on whether the containsReturnStatement is true OR false. If its true, the code is added as it is
+   *       If false, it'll added along with return statement.</li>
+   *   <li>Compile the expression using Janino library</li>
+   *   <li>Return an object of type Expression which contains compiled expression.</li>
+   * </ol>
+   *
+   * @param expression              String expression that needs to be compiled
+   * @param returnType              Return type of the expression.
+   * @param containsReturnStatement Whether the expression contains return statement OR not.
+   * @param <O>                     Parameterized return class type of expression after evaluation.
+   * @return                        Object of type Expression interface having compiled and executable expression.
+   */
+  @SuppressWarnings({"unchecked"})
+  private <O> Expression<O> createExecutableExpression(String expression, Class<?> returnType, boolean containsReturnStatement)
+  {
+    if (this.placeholderClassMapping.size() <= 0) {
+      throw new RuntimeException("Mapping needs to be provided.");
+    }
+
+    Pattern entry = Pattern.compile("\\$\\{(.*?)\\}");
+    Matcher matcher = entry.matcher(expression);
+    StringBuffer sb = new StringBuffer();
+    while (matcher.find()) {
+      if (matcher.groupCount() == 1) {
+        matcher.appendReplacement(sb, getObjectJavaExpression(matcher.group(1)));
+      } else {
+        throw new RuntimeException("Invalid expression: " + matcher.group());
+      }
+    }
+
+    matcher.appendTail(sb);
+
+    String code = getFinalMethodCode(sb.toString(), returnType, containsReturnStatement);
+    try {
+      IScriptEvaluator se = CompilerFactoryFactory.getDefaultCompilerFactory().newScriptEvaluator();
+      se.setDefaultImports(this.imports.toArray(new String[imports.size()]));
+      return (Expression)se.createFastEvaluator(code, Expression.class, new String[]{INP_OBJECT_FUNC_VAR});
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String getFinalMethodCode(String code, Class<?> returnType, boolean containsReturnStatement)
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("if (")
+      .append(INP_OBJECT_FUNC_VAR)
+      .append(".length != ")
+      .append(placeholderClassMapping.size())
+      .append(") {")
+      .append("throw new RuntimeException(\"Incorrect number of parameters passed to Expression.\");")
+      .append("}\n");
+
+    if (containsReturnStatement) {
+      sb.append(code);
+    } else {
+      sb.append("return (")
+        .append(returnType.getName())
+        .append(")(")
+        .append(code)
+        .append(");");
+    }
+
+    return sb.toString();
+  }
+
+  private String getObjectJavaExpression(String exp)
+  {
+    String[] split = exp.split("\\.");
+    if (split.length == 1) {
+      // Can be objectPlaceholder OR fieldExpression
+      return getSingleOperandReplacement(split[0]);
+    } else if (split.length > 0) {
+      try {
+        return getMultiOperandReplacement(split);
+      } catch (NoSuchFieldException e) {
+        throw new RuntimeException("Cannot find matching fields from given expression. " + exp);
+      }
+    } else {
+      throw new RuntimeException("No operand find. " + exp);
+    }
+  }
+
+  private String getMultiOperandReplacement(String[] split) throws NoSuchFieldException
+  {
+    StringBuilder sb = new StringBuilder();
+    if (this.placeholderClassMapping.containsKey(split[0])) {
+      Class classType = this.placeholderClassMapping.get(split[0]);
+      sb.append(getSingleOperandReplacement(split[0]));
+
+      for (int i = 1; i < split.length; i++) {
+        sb.append(".")
+          .append(getGetterForVariable(split[i], classType));
+        classType = classType.getDeclaredField(split[i]).getType();
+      }
+    } else {
+      throw new RuntimeException("First index in operand should be objectPlaceholder" + split.toString());
+    }
+
+    return sb.toString();
+  }
+
+  private String getSingleOperandReplacement(String operand)
+  {
+    StringBuilder sb = new StringBuilder();
+    String objectPlaceholder;
+    Class classType;
+    if (this.placeholderClassMapping.containsKey(operand)) {
+      // This is object placeholder.
+      objectPlaceholder = operand;
+      classType = this.placeholderClassMapping.get(operand);
+    } else {
+      // This operand is a field variable. Find objectPlaceholder & its class for this.
+      // Pick first of the mapping. Give warning if more than one placeholders are registered.
+      Map.Entry<String, Class> mapping = this.placeholderClassMapping.entrySet().iterator().next();
+      if (this.placeholderClassMapping.size() > 1) {
+        logger.warn("More than one placeholder registered. Picking first one.");
+      }
+      objectPlaceholder = mapping.getKey();
+      classType = mapping.getValue();
+    }
+
+    String replacement = INP_OBJECT_FUNC_VAR + "[" + this.placeholderIndexMapping.get(objectPlaceholder) + "]";
+    sb.append("(")
+      .append("(")
+      .append(classType.getName().replace("$", "\\$"))
+      .append(")")
+      .append("(")
+      .append(replacement)
+      .append(")")
+      .append(")");
+
+    if (!this.placeholderClassMapping.containsKey(operand)) {
+      // This is fieldPlaceholder. Append getter to expression.
+      sb.append(".")
+        .append(getGetterForVariable(operand, classType));
+    }
+
+    return sb.toString();
+  }
+
+  private String getGetterForVariable(String var, Class inputClassType)
+  {
+    try {
+      final Field field = inputClassType.getField(var);
+      if (Modifier.isPublic(field.getModifiers())) {
+        return var;
+      }
+      logger.debug("Field {} is not publicly accessible. Proceeding to locate a getter method.", var);
+    } catch (NoSuchFieldException ex) {
+      logger.debug("{} does not have field {}. Proceeding to locate a getter method.", inputClassType.getName(), var);
+    } catch (SecurityException ex) {
+      logger.debug("{} does not have field {}. Proceeding to locate a getter method.", inputClassType.getName(), var);
+    }
+
+    String methodName = GET + var.substring(0, 1).toUpperCase() + var.substring(1);
+    try {
+      Method method = inputClassType.getMethod(methodName);
+      if (Modifier.isPublic(method.getModifiers())) {
+        return methodName + "()";
+      }
+      logger.debug("Method {} of {} is not accessible. Proceeding to locate another getter method.", methodName, inputClassType.getName());
+    } catch (NoSuchMethodException ex) {
+      logger.debug("{} does not have method {}. Proceeding to locate another getter method", inputClassType.getName(), methodName);
+    } catch (SecurityException ex) {
+      logger.debug("{} does not have method {}. Proceeding to locate another getter method", inputClassType.getName(), methodName);
+    }
+
+    methodName = IS + var.substring(0, 1).toUpperCase() + var.substring(1);
+    try {
+      Method method = inputClassType.getMethod(methodName);
+      if (Modifier.isPublic(method.getModifiers())) {
+        return methodName + "()";
+      }
+      logger.debug("Method {} of {} is not accessible. Proceeding to locate another getter method.", methodName, inputClassType.getName());
+    } catch (NoSuchMethodException ex) {
+      logger.debug("{} does not have method {}. Proceeding to locate another getter method", inputClassType.getName(), methodName);
+    } catch (SecurityException ex) {
+      logger.debug("{} does not have method {}. Proceeding to locate another getter method", inputClassType.getName(), methodName);
+    }
+
+    throw new IllegalArgumentException("Field '" + var + "' is not found in given class " + inputClassType.getName());
+  }
+
+  /**
+   * This private method add default imports for compiling the expression.
+   * The import that are added here can be directly used inside Expression.
+   */
+  private void addDefaultImports()
+  {
+    imports.add("java.util.*");
+    imports.add("java.math.*");
+    imports.add("java.text.*");
+
+    // Pre-existing
+    imports.add("static java.lang.Math.*");
+    imports.add("static org.apache.commons.lang3.StringUtils.*");
+    imports.add("static org.apache.commons.lang3.StringEscapeUtils.*");
+    imports.add("static org.apache.commons.lang3.time.DurationFormatUtils.*");
+    imports.add("static org.apache.commons.lang3.time.DateFormatUtils.*");
+    imports.add("static org.apache.commons.lang3.time.DateUtils.*");
+
+    // Custom ones
+    imports.add("static com.datatorrent.lib.expressions.ConversionUtils.*");
+    imports.add("static com.datatorrent.lib.expressions.StringUtils.*");
+    imports.add("static com.datatorrent.lib.expressions.DateTimeUtils.*");
+  }
+
+  /**
+   * This method adds any given package to the default list of imports.
+   * The import that are added here can be directly used inside Expression.
+   * @param importPackage
+   */
+  public void addImports(String importPackage)
+  {
+    imports.add(importPackage);
+  }
+
+  /**
+   * This method overrides the list of imports currently set for expression evaluation.
+   * Except java.lang will remain there for technical reason.
+   * After call to this method, following list of imports will be added to the file:
+   * <ul>
+   *   <li>java.lang</li>
+   *   <li>One present in importPackages</li>
+   * </ul>
+   *
+   * @param importPackages List of import packages that needs to be set for expression evaluation.
+   */
+  public void overrideImports(String[] importPackages)
+  {
+    imports.clear();
+    imports.addAll(Arrays.asList(importPackages));
+  }
+
+  /**
+   * This method can add a public static custom function to be made available while expression evaluation.
+   * The parameter passed to the function should be qualified i.e. it should be prepended with classname as well.
+   * For eg.
+   * <p>
+   *   Lets say there is a class which has public static function:
+   *   package com.package.name.something;
+   *
+   *   public class Example
+   *   {
+   *     public static compute(<params>)
+   *     {
+   *       <operations>
+   *     }
+   *   }
+   *
+   *   Calling registerCustomMethod("com.package.name.something.Example.compute") will add compute method to be directly
+   *   available in Expression Language.
+   * </p>
+   * @param qualifiedFunc
+   */
+  public void registerCustomMethod(String qualifiedFunc)
+  {
+    addImports("static " + qualifiedFunc);
+  }
+
+  /**
+   * This method provides order and mapping is object placeholder vs their class types.
+   * The order in which the inputObjectPlaceholders are added, the same order needs to be followed while passing
+   * parameters to execute method as well.
+   *
+   * inputObjectPlaceholder are the string placeholder which can be used in expression to reference the object
+   * that is passed to execute method of Expression class.
+   *
+   * <b>NOTE: This registers the order in which parameters are passed to execute method. </b>
+   *
+   * @param inputObjectPlaceholders Array of string placeholder that can be used in expression to reference the object.
+   * @param classTypes              Class type of respective string placeholders in expression.
+   */
+  public void setInputObjectPlaceholders(String[] inputObjectPlaceholders, Class[] classTypes)
+  {
+    this.placeholderClassMapping.clear();
+    this.placeholderIndexMapping.clear();
+    for (int i = 0; i < inputObjectPlaceholders.length; i++) {
+      this.placeholderClassMapping.put(inputObjectPlaceholders[i], classTypes[i]);
+      this.placeholderIndexMapping.put(inputObjectPlaceholders[i], i);
+    }
+  }
+}

--- a/library/src/main/java/com/datatorrent/lib/expressions/ExpressionEvaluator.java
+++ b/library/src/main/java/com/datatorrent/lib/expressions/ExpressionEvaluator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 DataTorrent, Inc.
+ * Copyright (c) 2016 DataTorrent, Inc.
  * All rights reserved.
  */
 package com.datatorrent.lib.expressions;

--- a/library/src/main/java/com/datatorrent/lib/expressions/StringUtils.java
+++ b/library/src/main/java/com/datatorrent/lib/expressions/StringUtils.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2015 DataTorrent, Inc.
+ * All rights reserved.
+ */
+package com.datatorrent.lib.expressions;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class StringUtils
+{
+  public static boolean equalsWithCase(String str1, String str2)
+  {
+    return org.apache.commons.lang3.StringUtils.equals(str1, str2);
+  }
+
+  public static String truncate(String str, int length)
+  {
+    return (str == null) ? null : str.substring(0, length);
+  }
+
+  public static String regexCapture(String str, String regex, int groupId)
+  {
+    if (groupId <= 0) {
+      return null;
+    }
+
+    Pattern entry = Pattern.compile(regex);
+    Matcher matcher = entry.matcher(str);
+
+    return matcher.find() ? matcher.group(groupId) : null;
+  }
+}

--- a/library/src/main/java/com/datatorrent/lib/expressions/StringUtils.java
+++ b/library/src/main/java/com/datatorrent/lib/expressions/StringUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 DataTorrent, Inc.
+ * Copyright (c) 2016 DataTorrent, Inc.
  * All rights reserved.
  */
 package com.datatorrent.lib.expressions;

--- a/library/src/test/java/com/datatorrent/lib/expressions/ExpressionApplicationTest.java
+++ b/library/src/test/java/com/datatorrent/lib/expressions/ExpressionApplicationTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2015 DataTorrent, Inc.
+ * All rights reserved.
+ */
+package com.datatorrent.lib.expressions;
+
+import com.datatorrent.api.*;
+import com.datatorrent.common.util.BaseOperator;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolationException;
+
+public class ExpressionApplicationTest
+{
+  @Test public void testExpressionApplication() throws Exception
+  {
+    try {
+      LocalMode lma = LocalMode.newInstance();
+      Configuration conf = new Configuration(false);
+      lma.prepareDAG(new ExpressionApplication(), conf);
+      LocalMode.Controller lc = lma.getController();
+      lc.run(10000); // runs for 10 seconds and quits
+    } catch (ConstraintViolationException e) {
+      Assert.fail("constraint violations: " + e.getConstraintViolations());
+    }
+  }
+
+  public static class ExpressionApplication implements StreamingApplication
+  {
+    @Override public void populateDAG(DAG dag, Configuration configuration)
+    {
+      String exp = "upperCase(${" + DummyProcessor.VARIABLE_PLACEHOLDER + ".firstname}) + " +
+          "\" \" + " +
+          "upperCase(${" + DummyProcessor.VARIABLE_PLACEHOLDER + ".lastname})";
+
+      DummyInputGenerator input = dag.addOperator("Input", new DummyInputGenerator());
+      DummyProcessor processor = dag.addOperator("Processor", new DummyProcessor());
+      processor.setStringExp(exp);
+
+      dag.addStream("Connect", input.output, processor.input);
+    }
+  }
+
+  public static class TestPojo
+  {
+    private String firstname;
+    public String lastname;
+
+    public TestPojo()
+    {
+      //for kryo
+    }
+
+    public TestPojo(String firstname, String lastname)
+    {
+      this.firstname = firstname;
+      this.lastname = lastname;
+    }
+
+    public String getFirstname()
+    {
+      return firstname;
+    }
+
+    public void setFirstname(String firstname)
+    {
+      this.firstname = firstname;
+    }
+  }
+
+  public static class DummyInputGenerator implements InputOperator
+  {
+    public final transient DefaultOutputPort<TestPojo> output = new DefaultOutputPort<>();
+
+    @Override public void emitTuples()
+    {
+      output.emit(new TestPojo("FirstName", "LastName"));
+    }
+
+    @Override public void beginWindow(long l)
+    {
+    }
+
+    @Override public void endWindow()
+    {
+    }
+
+    @Override public void setup(Context.OperatorContext context)
+    {
+    }
+
+    @Override public void teardown()
+    {
+    }
+  }
+
+  public static class DummyProcessor extends BaseOperator
+  {
+    public static String VARIABLE_PLACEHOLDER = "inp";
+
+    private String stringExp;
+    private ExpressionEvaluator ee;
+    private ExpressionEvaluator.Expression expression;
+
+    public final transient DefaultInputPort<TestPojo> input = new DefaultInputPort<TestPojo>()
+    {
+      @Override public void process(TestPojo testPojo)
+      {
+        Object result = expression.execute(testPojo);
+        Assert.assertTrue(result instanceof String);
+        String result1 = (String)result;
+        Assert.assertEquals("FIRSTNAME LASTNAME", result1);
+      }
+    };
+
+    @Override public void setup(Context.OperatorContext context)
+    {
+      ee = new ExpressionEvaluator();
+      ee.setInputObjectPlaceholders(new String[] { VARIABLE_PLACEHOLDER }, new Class[] { TestPojo.class });
+      expression = ee.createExecutableExpression(stringExp, String.class);
+    }
+
+    public String getStringExp()
+    {
+      return stringExp;
+    }
+
+    public void setStringExp(String stringExp)
+    {
+      this.stringExp = stringExp;
+    }
+  }
+}

--- a/library/src/test/java/com/datatorrent/lib/expressions/ExpressionApplicationTest.java
+++ b/library/src/test/java/com/datatorrent/lib/expressions/ExpressionApplicationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 DataTorrent, Inc.
+ * Copyright (c) 2016 DataTorrent, Inc.
  * All rights reserved.
  */
 package com.datatorrent.lib.expressions;

--- a/library/src/test/java/com/datatorrent/lib/expressions/ExpressionEvaluatorTest.java
+++ b/library/src/test/java/com/datatorrent/lib/expressions/ExpressionEvaluatorTest.java
@@ -1,0 +1,403 @@
+/**
+ * Copyright (c) 2015 DataTorrent, Inc.
+ * All rights reserved.
+ */
+package com.datatorrent.lib.expressions;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExpressionEvaluatorTest
+{
+  @Test
+  public void testBasic() throws Exception
+  {
+    POJO1 pojo = createTestPOJO1();
+
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{POJO1.class});
+
+    // Operand type: ${objectPlaceholder.fieldName}
+    String expression = "${inp.a}";
+    ExpressionEvaluator.Expression<Integer> getter = ee.createExecutableExpression(expression, Integer.class);
+    Integer age = getter.execute(pojo);
+    Assert.assertEquals(12, age.intValue());
+
+    // Operand type: ${fieldName}
+    expression = "${a}";
+    getter = ee.createExecutableExpression(expression, Integer.class);
+    age = getter.execute(pojo);
+    Assert.assertEquals(12, age.intValue());
+
+    // Operand type: ${fieldName} with multiple registered placeholders.
+    ee.setInputObjectPlaceholders(new String[]{"inp", "inpA"}, new Class[]{POJO1.class, POJO1.class});
+    expression = "${a}";
+    getter = ee.createExecutableExpression(expression, Integer.class);
+    age = getter.execute(pojo, pojo);
+    Assert.assertEquals(12, age.intValue());
+
+    // Operand type: ${objectPlaceholder}
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{Integer.class});
+    expression = "${inp} * 2";
+    getter = ee.createExecutableExpression(expression, Integer.class);
+    age = getter.execute(new Integer(6));
+    Assert.assertEquals(12, age.intValue());
+
+    // Operand type: ${objectPlaceholder} with placeholder same as variable name
+    ee.setInputObjectPlaceholders(new String[]{"a"}, new Class[]{Integer.class});
+    expression = "${a} * 2";
+    getter = ee.createExecutableExpression(expression, Integer.class);
+    age = getter.execute(new Integer(66));
+    Assert.assertEquals(132, age.intValue());
+
+    // Operand type : Nested Operands ${objectPlaceholder.fieldName1.fieldName2}
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{NestedPOJO.class});
+    expression = "${inp.innerPOJO.a} + toInt(${inp.innerPOJO.b}) + ${inp.innerPOJO2.a} + toInt(${inp.innerPOJO2.b})";
+    getter = ee.createExecutableExpression(expression, Integer.class);
+
+    NestedPOJO nestedPOJO = new NestedPOJO();
+    nestedPOJO.setInnerPOJO(createTestPOJO1());
+    nestedPOJO.innerPOJO2 = createTestPOJO1();
+    age = getter.execute(nestedPOJO);
+    Assert.assertEquals(50, age.intValue());
+  }
+
+  @Test
+  public void testAddition() throws Exception
+  {
+    POJO1 pojo = createTestPOJO1();
+
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{POJO1.class});
+
+    String expression = "${inp.a} + ${inp.b}";
+    ExpressionEvaluator.Expression<Long> getter = ee.createExecutableExpression(expression, Long.class);
+    Long addition = getter.execute(pojo);
+    Assert.assertEquals(25, addition.longValue());
+  }
+
+  @Test
+  public void testReuse() throws Exception
+  {
+    POJO1 pojo = createTestPOJO1();
+
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{POJO1.class});
+
+    String expression1 = "${inp.a} + ${inp.b}";
+    ExpressionEvaluator.Expression<Long> getter1 = ee.createExecutableExpression(expression1, Long.class);
+    Long addition = getter1.execute(pojo);
+    Assert.assertEquals(25, addition.longValue());
+  }
+
+  @Test
+  public void testMultiplication() throws Exception
+  {
+    POJO1 pojo = createTestPOJO1();
+
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{POJO1.class});
+
+    String expression = "${inp.a} * ${inp.b}";
+    ExpressionEvaluator.Expression<Long> getter = ee.createExecutableExpression(expression, Long.class);
+    Long mult = getter.execute(pojo);
+    Assert.assertEquals(156, mult.longValue());
+  }
+
+  @Test
+  public void testCasting() throws Exception
+  {
+    POJO1 pojo = createTestPOJO1();
+
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{POJO1.class});
+
+    String expression = "(int) (${inp.a} * ${inp.b})";
+    ExpressionEvaluator.Expression<Integer> getter = ee.createExecutableExpression(expression, Integer.class);
+    Integer mult = getter.execute(pojo);
+    Assert.assertEquals(156, mult.intValue());
+  }
+
+  @Test
+  public void testCondition() throws Exception
+  {
+    POJO1 pojo = createTestPOJO1();
+    pojo.setA(1);
+    pojo.setB(1);
+
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{POJO1.class});
+
+    String expression = "(${inp.a} * ${inp.b}) > 0 ? ${inp.name1} : ${inp.name2}";
+    ExpressionEvaluator.Expression<String> getter = ee.createExecutableExpression(expression, String.class);
+
+    String result = getter.execute(pojo);
+    Assert.assertEquals("Apex", result);
+
+    pojo.setA(-1);
+    result = getter.execute(pojo);
+    Assert.assertEquals("DataTorrent", result);
+
+    pojo.setB(-1);
+    result = getter.execute(pojo);
+    Assert.assertEquals("Apex", result);
+  }
+
+  @Test
+  public void testStringConcat() throws Exception
+  {
+    POJO1 pojo = createTestPOJO1();
+    pojo.setA(1);
+    pojo.setB(1);
+
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{POJO1.class});
+
+    String expression = "${inp.name2} + \" \" + ${inp.name1}";
+    ExpressionEvaluator.Expression<String> getter = ee.createExecutableExpression(expression, String.class);
+
+    String result = getter.execute(pojo);
+    Assert.assertEquals("DataTorrent Apex", result);
+  }
+
+  @Test
+  public void testStringEmptyCheck() throws Exception
+  {
+    POJO1 pojo = createTestPOJO1();
+
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{POJO1.class});
+
+    String expression = "isEmpty(${inp.name1})";
+    ExpressionEvaluator.Expression<Boolean> getter = ee.createExecutableExpression(expression, Boolean.class);
+
+    Boolean result = getter.execute(pojo);
+    Assert.assertEquals(false, result);
+
+    pojo.name1 = "";
+    result = getter.execute(pojo);
+    Assert.assertEquals(true, result);
+
+    pojo.name1 = null;
+    result = getter.execute(pojo);
+    Assert.assertEquals(true, result);
+
+    pojo.name1 = "Apex";
+    String expression1 = "isEmpty(${inp.name1}) ? \"True\" : \"False\"";
+    ExpressionEvaluator.Expression<String> getter1 = ee.createExecutableExpression(expression1, String.class);
+    String result1 = getter1.execute(pojo);
+    Assert.assertEquals("False", result1);
+
+    pojo.name1 = null;
+    result1 = getter1.execute(pojo);
+    Assert.assertEquals("True", result1);
+  }
+
+  @Test
+  public void testStringEqualsCheck() throws Exception
+  {
+    POJO1 pojo = createTestPOJO1();
+
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{POJO1.class});
+
+    String expression = "equalsWithCase(${inp.name1}, ${inp.name2}) ? true: false";
+    ExpressionEvaluator.Expression<Boolean> getter = ee.createExecutableExpression(expression, Boolean.class);
+
+    Boolean result = getter.execute(pojo);
+    Assert.assertEquals(false, result);
+
+    pojo.name1 = "Datatorrent";
+    result = getter.execute(pojo);
+    Assert.assertEquals(false, result);
+
+    pojo.name1 = "DataTorrent";
+    result = getter.execute(pojo);
+    Assert.assertEquals(true, result);
+  }
+
+  @Test
+  public void testMultiplePOJO() throws Exception
+  {
+    POJO1 pojo1 = createTestPOJO1();
+    POJO2 pojo2 = createTestPOJO2();
+
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inpA", "inpB"}, new Class[]{POJO1.class, POJO2.class});
+
+    String expression = "equalsWithCase(${inpA.name1}, ${inpA.name2}) ? ${inpB.a} : ${inpB.b}";
+    ExpressionEvaluator.Expression<Double> getter = ee.createExecutableExpression(expression, Double.class);
+
+    Double result = getter.execute(pojo1, pojo2);
+    Assert.assertEquals(pojo2.getB(), result.doubleValue(), 0.0);
+
+    pojo1.name1 = "DataTorrent";
+    result = getter.execute(pojo1, pojo2);
+    Assert.assertEquals(pojo2.getA(), result.doubleValue(), 0.0);
+
+    String expression1 = "equalsWithCase(${inpA.name1}, ${inpA.name2}) ? ${inpB.a} : toInt(${inpB.b})";
+    ExpressionEvaluator.Expression<Integer> getter1 = ee.createExecutableExpression(expression1, Integer.class);
+
+    Integer result1 = getter1.execute(pojo1, pojo2);
+    Assert.assertEquals(pojo2.getA(), result1.intValue());
+
+    pojo1.name1 = "DataTorrent";
+    result1 = getter1.execute(pojo1, pojo2);
+    System.out.println(result1);
+    Assert.assertEquals(new Double(pojo2.getB()).intValue(), result1.intValue());
+  }
+
+  @Test
+  public void testCompleteFunction() throws Exception
+  {
+    POJO1 pojo = createTestPOJO1();
+
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{POJO1.class});
+
+    String expression = "long retVal = 1; for (int i=0;i<${inp.a};i++) { retVal = retVal * ${inp.b}; } return retVal;";
+    ExpressionEvaluator.Expression<Long> getter = ee.createExecutableFunction(expression, Long.class);
+
+    Long result = getter.execute(pojo);
+    Assert.assertEquals(new Double(Math.pow(pojo.b, pojo.getA())).longValue(), result.longValue());
+  }
+
+  @Test
+  public void testAddCustomMethod()
+  {
+    NestedPOJO nestedPOJO = new NestedPOJO();
+    nestedPOJO.setInnerPOJO(createTestPOJO1());
+    nestedPOJO.innerPOJO2 = createTestPOJO1();
+
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{NestedPOJO.class});
+    ee.registerCustomMethod("com.datatorrent.lib.expressions.ExpressionEvaluatorTest.customMethod");
+
+    String expression = "${inp.innerPOJO.name1} + customMethod(${inp})";
+    ExpressionEvaluator.Expression exp = ee.createExecutableExpression(expression, String.class);
+    Object result = exp.execute(nestedPOJO);
+    Assert.assertTrue(result instanceof String);
+    String result1 = (String)result;
+    Assert.assertEquals("Apex25", result1);
+  }
+
+  public static long customMethod(NestedPOJO pojo)
+  {
+    return pojo.getInnerPOJO().getA() + pojo.innerPOJO2.b;
+  }
+
+  private POJO1 createTestPOJO1()
+  {
+    POJO1 pojo = new POJO1();
+    pojo.setA(12);
+    pojo.setB(13);
+    pojo.setD(new Date(1988 - 1900, 2, 11));
+    pojo.name1 = "Apex";
+    pojo.name2 = "DataTorrent";
+
+    return pojo;
+  }
+
+  private POJO2 createTestPOJO2()
+  {
+    POJO2 pojo = new POJO2();
+    pojo.setA(1234);
+    pojo.setB(1234.56D);
+    return pojo;
+  }
+
+  public static class POJO1
+  {
+    private int a;
+    public long b;
+    private Date d;
+    public String name1;
+    public String name2;
+
+    public int getA()
+    {
+      return a;
+    }
+
+    public void setA(int a)
+    {
+      this.a = a;
+    }
+
+    public long getB()
+    {
+      return b;
+    }
+
+    public void setB(long b)
+    {
+      this.b = b;
+    }
+
+    public Date getD()
+    {
+      return d;
+    }
+
+    public void setD(Date d)
+    {
+      this.d = d;
+    }
+  }
+
+  public static class POJO2
+  {
+    private int a;
+    private double b;
+
+    public int getA()
+    {
+      return a;
+    }
+
+    public void setA(int a)
+    {
+      this.a = a;
+    }
+
+    public double getB()
+    {
+      return b;
+    }
+
+    public void setB(double b)
+    {
+      this.b = b;
+    }
+  }
+
+  public static class NestedPOJO
+  {
+    private POJO1 innerPOJO;
+    public POJO1 innerPOJO2;
+
+    public POJO1 getInnerPOJO()
+    {
+      return innerPOJO;
+    }
+
+    public void setInnerPOJO(POJO1 innerPOJO)
+    {
+      this.innerPOJO = innerPOJO;
+    }
+  }
+
+}

--- a/library/src/test/java/com/datatorrent/lib/expressions/ExpressionEvaluatorTest.java
+++ b/library/src/test/java/com/datatorrent/lib/expressions/ExpressionEvaluatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 DataTorrent, Inc.
+ * Copyright (c) 2016 DataTorrent, Inc.
  * All rights reserved.
  */
 package com.datatorrent.lib.expressions;

--- a/library/src/test/java/com/datatorrent/lib/expressions/ExpressionPerformanceTest.java
+++ b/library/src/test/java/com/datatorrent/lib/expressions/ExpressionPerformanceTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2015 DataTorrent, Inc.
+ * All rights reserved.
+ */
+package com.datatorrent.lib.expressions;
+
+import java.util.Date;
+import com.datatorrent.lib.expressions.ExpressionEvaluatorTest.POJO1;
+import com.datatorrent.lib.expressions.ExpressionEvaluatorTest.POJO2;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExpressionPerformanceTest
+{
+  private static final Logger logger = LoggerFactory.getLogger(ExpressionPerformanceTest.class);
+
+  @Test
+  public void testExpressionPerformance() throws Exception
+  {
+    logger.info("===Expression performance tests===");
+    logger.info("---1 million---");
+    runExpressionPerformance(1000000);
+    logger.info("---10 million---");
+    runExpressionPerformance(10000000);
+    logger.info("---100 million---");
+    runExpressionPerformance(100000000);
+    logger.info("---1 billion---");
+    runExpressionPerformance(1000000000);
+  }
+
+  @Test
+  public void testFunctionPerformance() throws Exception
+  {
+    logger.info("===Function performance tests===");
+    logger.info("---1 million---");
+    runFunctionPerformance(1000000);
+    logger.info("---10 million---");
+    runFunctionPerformance(10000000);
+  }
+
+  @Test
+  public void testMathExpressionPerformance() throws Exception
+  {
+    logger.info("===Math Expression performance tests===");
+    logger.info("---1 million---");
+    runMathExpressionPerformance(1000000);
+    logger.info("---10 million---");
+    runMathExpressionPerformance(10000000);
+  }
+
+  public void runMathExpressionPerformance(int count) throws Exception
+  {
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inp"}, new Class[]{Double.class});
+
+    String expression1 = "2 + (7-5) * 3.14159 * ${inp} + sin(${inp})";
+    ExpressionEvaluator.Expression getter = ee.createExecutableExpression(expression1, double.class);
+
+    long startTime = System.currentTimeMillis();
+    for (int i=0; i < count; i++) {
+      getter.execute((double) i);
+    }
+    long timeTaken = (System.currentTimeMillis() - startTime);
+    logger.info("Time taken for running " + count + " executions in ms: " + timeTaken);
+    logger.info("Executions per sec: " + ((long)count * 1000 / timeTaken));
+  }
+
+  public void runExpressionPerformance(int count) throws Exception
+  {
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inpA", "inpB"}, new Class[]{POJO1.class, POJO2.class});
+
+    String expression1 = "equalsWithCase(${inpA.name1}, ${inpA.name2}) ? ${inpB.a} * ${inpB.a} : toInt(${inpB.b}) * toInt(${inpB.b})";
+    ExpressionEvaluator.Expression<Integer> getter = ee.createExecutableExpression(expression1, Integer.class);
+
+    POJO1 testPOJO11 = createTestPOJO1();
+    POJO2 testPOJO2 = createTestPOJO2();
+
+    POJO1 testPOJO12 = createTestPOJO1();
+    testPOJO12.name1 = "DataTorrent";
+
+    long startTime = System.currentTimeMillis();
+    for (int i=0; i < count; i++) {
+      if ( i%2 == 0) {
+        getter.execute(testPOJO11, testPOJO2);
+      }
+      else {
+        getter.execute(testPOJO12, testPOJO2);
+      }
+    }
+    long timeTaken = (System.currentTimeMillis() - startTime);
+    logger.info("Time taken for running " + count + " executions in ms: " + timeTaken);
+    logger.info("Executions per sec: " + ((long)count * 1000 / timeTaken));
+  }
+
+  public void runFunctionPerformance(int count) throws Exception
+  {
+    ExpressionEvaluator ee = new ExpressionEvaluator();
+    // Let expression evaluator know what are the object mappings present in expressions and their class types.
+    ee.setInputObjectPlaceholders(new String[]{"inpA", "inpB"}, new Class[]{POJO1.class, POJO2.class});
+
+    String expression1 = "long retVal = 1; " +
+                          "if (equalsWithCase(${inpA.name1}, ${inpA.name2})) { " +
+                          "  for (int i=0;i< ${inpA.a}; i++) {" +
+                          "    retVal = retVal * ${inpA.a};" +
+                          "  }" +
+                          "} else {" +
+                          "  for (int i=0;i<${inpB.a};i++) {" +
+                          "    retVal = retVal * ${inpB.a};" +
+                          "  }" +
+                          "} " +
+                          "return retVal;";
+    ExpressionEvaluator.Expression<Long> getter = ee.createExecutableFunction(expression1, Long.class);
+
+    POJO1 testPOJO11 = createTestPOJO1();
+    POJO2 testPOJO2 = createTestPOJO2();
+
+    POJO1 testPOJO12 = createTestPOJO1();
+    testPOJO12.name1 = "DataTorrent";
+
+    long startTime = System.currentTimeMillis();
+    for (int i=0; i < count; i++) {
+      if ( i%2 == 0) {
+        getter.execute(testPOJO11, testPOJO2);
+      }
+      else {
+        getter.execute(testPOJO12, testPOJO2);
+      }
+    }
+    long timeTaken = (System.currentTimeMillis() - startTime);
+    logger.info("Time taken for running " + count + " executions in ms: " + timeTaken);
+    logger.info("Executions per sec: " + ((long)count * 1000 / timeTaken));
+  }
+
+  private POJO1 createTestPOJO1()
+  {
+    POJO1 pojo = new POJO1();
+    pojo.setA(12);
+    pojo.setB(13);
+    pojo.setD(new Date(1988 - 1900, 2, 11));
+    pojo.name1 = "Apex";
+    pojo.name2 = "DataTorrent";
+
+    return pojo;
+  }
+
+  private POJO2 createTestPOJO2()
+  {
+    POJO2 pojo = new POJO2();
+    pojo.setA(1234);
+    pojo.setB(1234.56D);
+    return pojo;
+  }
+
+}

--- a/library/src/test/java/com/datatorrent/lib/expressions/ExpressionPerformanceTest.java
+++ b/library/src/test/java/com/datatorrent/lib/expressions/ExpressionPerformanceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 DataTorrent, Inc.
+ * Copyright (c) 2016 DataTorrent, Inc.
  * All rights reserved.
  */
 package com.datatorrent.lib.expressions;


### PR DESCRIPTION
The expresion are based on java expressions except the operands needs to be registered before and put inside ${}.

The expression evaluator gives options to evaluate a complete function as well as an expression.

The evaluator provides with some basic utilities to be used directly into expression and also give freedom to add a custom method to be registered with ExpressionEvaluator.
This custom method once registered becomes callable into expression directly.

Design doc for this is here:
https://docs.google.com/document/d/1SZfQcsxcu4-ndFFIt2pAZBgm_pdJBLfoKU4RAw1dGcM
