### PR TITLE
SPOI-7309 #resolve avoid frequent wal flushes.

### DIFF
--- a/contrib/src/main/java/com/datatorrent/contrib/hdht/HDHTWalManager.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/hdht/HDHTWalManager.java
@@ -86,12 +86,6 @@ public class HDHTWalManager implements Closeable
   /* Backing file system for WAL */
   transient HDHTFileAccess bfs;
 
-  /*
-   * If maximum number of bytes allowed to be written to file between flush,
-   * default is 64K.
-   */
-  transient long maxUnflushedBytes = 64 * 1024;
-
   /* Maximum number of bytes per WAL file,
    * default is 128M */
   transient long maxWalFileSize = 128 * 1024 * 1024;
@@ -224,9 +218,6 @@ public class HDHTWalManager implements Closeable
     int len = writer.append(entry);
     stats.totalBytes += len;
     dirty = true;
-    if (maxUnflushedBytes > 0 && writer.getSize() > maxUnflushedBytes) {
-      flushWal();
-    }
   }
 
   protected void flushWal() throws IOException
@@ -296,14 +287,15 @@ public class HDHTWalManager implements Closeable
     this.maxWalFileSize = maxWalFileSize;
   }
 
+  @Deprecated
   public long getMaxUnflushedBytes()
   {
-    return maxUnflushedBytes;
+    return Long.MAX_VALUE;
   }
 
+  @Deprecated
   public void setMaxUnflushedBytes(long maxUnflushedBytes)
   {
-    this.maxUnflushedBytes = maxUnflushedBytes;
   }
 
   public long getFlushedWid()


### PR DESCRIPTION
Once WAL crosses maxUnflushedBytes, it results in flush on every data write, because of wrong condition. The old log used to return unflushed bytes but new log has removed that method. As log writer does not provide unflushed bytes len, deprecate the functionality. This functionality is not needed as log is flushed in endWindow anyway. 
